### PR TITLE
fix: set job record status upon creating

### DIFF
--- a/src/Grb.Building.Processor.Upload/Zip/Translators/GrbDbaseRecordsTranslator.cs
+++ b/src/Grb.Building.Processor.Upload/Zip/Translators/GrbDbaseRecordsTranslator.cs
@@ -26,7 +26,8 @@
                     EventType = (GrbEventType)record.EventType.Value,
                     GrbObject = (GrbObject)record.GRBOBJECT.Value,
                     GrId = record.GRID.Value == "-9" ? -9 : record.GRID.Value.AsIdentifier().Map(int.Parse),
-                    GrbObjectType = (GrbObjectType)record.TPC.Value
+                    GrbObjectType = (GrbObjectType)record.TPC.Value,
+                    Status = JobRecordStatus.Created
                 });
 
                 recordNumber = recordNumber.Next();


### PR DESCRIPTION
The first value of JobRecordStatus is Created. The original integer value of JobRecordStatus was 0. Upon creating a job record, the status was not set. So it's value would default to zero, which was valid. Then the Created integer value was changed to 1, but when creating a job record the status would still default to 0. This had as a consequence that the job processor didn't pick up the job records (queried for job records with status Created) and so nothing meaningul happened and the job was still completed.