### PR TITLE
feat: job is cancellable when in error but without job records

### DIFF
--- a/src/Grb.Building.Processor.Upload/UploadProcessor.cs
+++ b/src/Grb.Building.Processor.Upload/UploadProcessor.cs
@@ -24,7 +24,7 @@
     using Zip.Validators;
     using Task = System.Threading.Tasks.Task;
 
- public sealed class UploadProcessor : BackgroundService
+    public sealed class UploadProcessor : BackgroundService
     {
         private readonly BuildingGrbContext _buildingGrbContext;
         private readonly ITicketing _ticketing;
@@ -101,7 +101,7 @@
                         await UpdateJobStatus(job, JobStatus.Error, stoppingToken);
 
                         await _notificationService.PublishToTopicAsync(new NotificationMessage(
-                            nameof(Grb.Building.Processor.Upload),
+                            nameof(Upload),
                             $"Job '{job.Id}' placed in error due to validation problems.",
                             "Grb upload processor",
                             NotificationSeverity.Danger));
@@ -126,7 +126,7 @@
                     await UpdateJobStatus(job, JobStatus.Error, stoppingToken);
 
                     await _notificationService.PublishToTopicAsync(new NotificationMessage(
-                        nameof(Grb.Building.Processor.Upload),
+                        nameof(Upload),
                         $"Unexpected exception for job '{job.Id}'.",
                         "Grb upload processor",
                         NotificationSeverity.Danger));


### PR DESCRIPTION
When the job encounteres a (validation) error while unzipping, this means there's a problem with the supplied zip file. This has as a consequence that the job will have no job records. So the job cannot be remedied from error to a processing state by resolving the job record errors. So we decided that a job without job records was never processable and thus can be cancelled.